### PR TITLE
Fix condition checking in doPaste.

### DIFF
--- a/pasteimage.js
+++ b/pasteimage.js
@@ -35,7 +35,7 @@
 					var items = e.clipboardData.items;
 					if (items) {
 						// Search clipboard items for an image
-						for (var i = 0; i < items.length, items[i].type.indexOf("image") !== -1; i++) {
+						for (var i = 0; i < items.length; i++) {
 							if (items[i].type.indexOf("image") !== -1) {
 								foundImage = true;								
 								// Convert image to blob using File API	               
@@ -47,6 +47,7 @@
 								/* Convert the blob from clipboard to base64 */		
 								reader.readAsDataURL(blob);
 								foundImage = false;
+								break;
 							}
 						}
 					} else { 


### PR DESCRIPTION
Hi! Thanks for your plugin, it works!

Looks like your usage of the comma operator in wrong, though. When trying pasting an image in Chrome, an error will get thrown.

Using `break` instead fixes it.
